### PR TITLE
Stop clicking on an overlay from unfocusing the game

### DIFF
--- a/OverlayPlugin.Core/OverlayForm.cs
+++ b/OverlayPlugin.Core/OverlayForm.cs
@@ -90,10 +90,11 @@ namespace RainbowMage.OverlayPlugin
                 const int WS_EX_TOPMOST = 0x00000008;
                 const int WS_EX_LAYERED = 0x00080000;
                 const int CP_NOCLOSE_BUTTON = 0x200;
+                const int WS_EX_NOACTIVATE = 0x08000000;
 
                 var cp = base.CreateParams;
-                cp.ExStyle = cp.ExStyle | WS_EX_TOPMOST | WS_EX_LAYERED;
-                cp.ClassStyle = cp.ClassStyle | CP_NOCLOSE_BUTTON;
+                cp.ExStyle = cp.ExStyle | WS_EX_TOPMOST | WS_EX_LAYERED | WS_EX_NOACTIVATE;
+                cp.ClassStyle = cp.ClassStyle | CP_NOCLOSE_BUTTON | WS_EX_NOACTIVATE;
 
                 return cp;
             }


### PR DESCRIPTION
(Original PR from [RainbowMage/OverlayPlugin/PR#49](https://github.com/RainbowMage/OverlayPlugin/pull/49))

Dear @TehDavester, I'm trying to mainternance this plugin instead of @RainbowMage, and creating release 0.3.3.10 with latest stable CEF and bugfixes/improvments/etc. Could you please allow me to merge this PR?