### PR TITLE
Remove double-navigate on startup

### DIFF
--- a/OverlayPlugin.Core/OverlayBase.cs
+++ b/OverlayPlugin.Core/OverlayBase.cs
@@ -17,7 +17,6 @@ namespace RainbowMage.OverlayPlugin
         private KeyboardHook hook = new KeyboardHook();
         protected System.Timers.Timer timer;
         protected System.Timers.Timer xivWindowTimer;
-        Timer tTimer;
         /// <summary>
         /// オーバーレイがログを出力したときに発生します。
         /// </summary>
@@ -76,10 +75,6 @@ namespace RainbowMage.OverlayPlugin
         /// </summary>
         protected virtual void InitializeOverlay()
         {
-            tTimer = new Timer();
-            tTimer.Tick += TTimer_Tick;
-            tTimer.Interval = 1000;
-            tTimer.Enabled = false;
             try
             {
                 this.Overlay = new OverlayForm("about:blank", this.Config.MaxFrameRate);
@@ -148,7 +143,6 @@ namespace RainbowMage.OverlayPlugin
                 if (CheckUrl(this.Config.Url))
                 {
                     Navigate(this.Config.Url);
-                    tTimer.Enabled = true;
                 }
                 else
                 {
@@ -165,12 +159,6 @@ namespace RainbowMage.OverlayPlugin
             {
                 Log(LogLevel.Error, "InitializeOverlay: {0}", this.Name, ex);
             }
-        }
-
-        private void TTimer_Tick(object sender, EventArgs e)
-        {
-            Navigate(Config.Url);
-            tTimer.Enabled = false;
         }
 
         private ModifierKeys GetModifierKey(Keys modifier)


### PR DESCRIPTION
This removes a flash on startup along with wasted work doing everything an extra time, as described in the commit message.