### PR TITLE
Add a way for javascript to call back to the overlay plugin.

### DIFF
--- a/HtmlRenderer/BuiltinFunctionHandler.cs
+++ b/HtmlRenderer/BuiltinFunctionHandler.cs
@@ -11,10 +11,12 @@ namespace RainbowMage.HtmlRenderer
     {
         public event EventHandler<BroadcastMessageEventArgs> BroadcastMessage;
         public event EventHandler<SendMessageEventArgs> SendMessage;
+        public event EventHandler<SendMessageEventArgs> OverlayMessage;
         public event EventHandler<EndEncounterEventArgs> EndEncounter;
 
         public const string BroadcastMessageFunctionName = "broadcastMessage";
         public const string SendMessageFunctionName = "sendMessage";
+        public const string OverlayMessageFunctionName = "overlayMessage";
         public const string EndEncounterFunctionName = "endEncounter";
 
         protected override bool Execute(string name, CefV8Value obj, CefV8Value[] arguments, out CefV8Value returnValue, out string exception)
@@ -45,6 +47,22 @@ namespace RainbowMage.HtmlRenderer
                     if (SendMessage != null)
                     {
                         SendMessage(obj, new SendMessageEventArgs(arguments[0].GetStringValue(), arguments[1].GetStringValue()));
+                    }
+                }
+                else
+                {
+                    exception = "Invalid argument count.";
+                }
+
+                return true;
+            }
+            else if (name == OverlayMessageFunctionName)
+            {
+                if (arguments.Length > 1)
+                {
+                    if (OverlayMessage != null)
+                    {
+                        OverlayMessage(obj, new SendMessageEventArgs(arguments[0].GetStringValue(), arguments[1].GetStringValue()));
                     }
                 }
                 else

--- a/HtmlRenderer/LoadHandler.cs
+++ b/HtmlRenderer/LoadHandler.cs
@@ -22,6 +22,7 @@ namespace RainbowMage.HtmlRenderer
 
             var message = CefProcessMessage.Create("SetOverlayAPI");
             message.Arguments.SetString(0, frame.Name);
+            message.Arguments.SetString(1, this.renderer.OverlayName);
             browser.SendProcessMessage(CefProcessId.Renderer, message);
         }
 

--- a/HtmlRenderer/RenderProcessHandler.cs
+++ b/HtmlRenderer/RenderProcessHandler.cs
@@ -22,6 +22,10 @@ namespace RainbowMage.HtmlRenderer
             {
                 Renderer.OnSendMessage(o, e);
             };
+            this.builtinFunctionHandler.OverlayMessage += (o, e) =>
+            {
+                Renderer.OnOverlayMessage(o, e);
+            };
             this.builtinFunctionHandler.EndEncounter += (o, e) =>
             {
                 Renderer.OnRendererFeatureRequest(o, new RendererFeatureRequestEventArgs("EndEncounter"));
@@ -35,6 +39,7 @@ namespace RainbowMage.HtmlRenderer
                 // 対象のフレームを取得
                 var frameName = message.Arguments.GetString(0);
                 var frame = GetFrameByName(browser, frameName);
+                var overlayName = message.Arguments.GetString(1);
 
                 // API を設定
                 if (frame != null && frame.V8Context.Enter())
@@ -47,9 +52,14 @@ namespace RainbowMage.HtmlRenderer
                     var sendMessageFunction = CefV8Value.CreateFunction(
                          BuiltinFunctionHandler.SendMessageFunctionName,
                          builtinFunctionHandler);
+                    var overlayMessageFunction = CefV8Value.CreateFunction(
+                         BuiltinFunctionHandler.OverlayMessageFunctionName,
+                         builtinFunctionHandler);
                     var endEncounterFunction = CefV8Value.CreateFunction(
                          BuiltinFunctionHandler.EndEncounterFunctionName,
                          builtinFunctionHandler);
+
+                    apiObject.SetValue("overlayName", CefV8Value.CreateString(overlayName), CefV8PropertyAttribute.ReadOnly);
 
                     apiObject.SetValue(
                         BuiltinFunctionHandler.BroadcastMessageFunctionName,
@@ -58,6 +68,10 @@ namespace RainbowMage.HtmlRenderer
                     apiObject.SetValue(
                         BuiltinFunctionHandler.SendMessageFunctionName,
                         sendMessageFunction,
+                        CefV8PropertyAttribute.ReadOnly);
+                    apiObject.SetValue(
+                        BuiltinFunctionHandler.OverlayMessageFunctionName,
+                        overlayMessageFunction,
                         CefV8PropertyAttribute.ReadOnly);
                     apiObject.SetValue(
                         BuiltinFunctionHandler.EndEncounterFunctionName,

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -16,6 +16,7 @@ namespace RainbowMage.HtmlRenderer
 
         public static event EventHandler<BroadcastMessageEventArgs> BroadcastMessage;
         public static event EventHandler<SendMessageEventArgs> SendMessage;
+        public static event EventHandler<SendMessageEventArgs> OverlayMessage;
         public static event EventHandler<RendererFeatureRequestEventArgs> RendererFeatureRequest;
 
         // Guards access to |allBrowsers| across threads.
@@ -43,6 +44,10 @@ namespace RainbowMage.HtmlRenderer
             }
         }
 
+        public string OverlayName {
+          get { return overlayName; }
+        }
+
         private Client Client { get; set; }
 
         private int clickCount;
@@ -50,10 +55,11 @@ namespace RainbowMage.HtmlRenderer
         private DateTime lastClickTime;
         private int lastClickPosX;
         private int lastClickPosY;
+        private string overlayName;
 
-        public Renderer()
+        public Renderer(string overlayName)
         {
-            
+            this.overlayName = overlayName;
         }
 
         public void BeginRender(int width, int height, string url, int maxFrameRate = 30)
@@ -283,6 +289,12 @@ namespace RainbowMage.HtmlRenderer
             if (SendMessage != null)
             {
                 SendMessage(sender, e);
+            }
+        }
+
+        internal static void OnOverlayMessage(object sender, SendMessageEventArgs e) {
+            if (OverlayMessage != null) {
+                OverlayMessage(sender, e);
             }
         }
 

--- a/OverlayPlugin.Common/IOverlay.cs
+++ b/OverlayPlugin.Common/IOverlay.cs
@@ -57,5 +57,11 @@ namespace RainbowMage.OverlayPlugin
         /// </summary>
         /// <param name="message">メッセージの内容。</param>
         void SendMessage(string message);
+
+        /// <summary>
+        /// A message from javascript for the overlay plugin to consume.
+        /// </summary>
+        /// <param name="message">A string message created by the plugin javascript.</param>
+        void OverlayMessage(string message);
     }
 }

--- a/OverlayPlugin.Core/OverlayBase.cs
+++ b/OverlayPlugin.Core/OverlayBase.cs
@@ -77,7 +77,7 @@ namespace RainbowMage.OverlayPlugin
         {
             try
             {
-                this.Overlay = new OverlayForm("about:blank", this.Config.MaxFrameRate);
+                this.Overlay = new OverlayForm(this.Name, "about:blank", this.Config.MaxFrameRate);
 
                 // グローバルホットキーを設定
                 if (this.Config.GlobalHotkeyEnabled)
@@ -382,6 +382,10 @@ namespace RainbowMage.OverlayPlugin
             {
                 this.Overlay.Renderer.ExecuteScript(script);
             }
+        }
+
+        public virtual void OverlayMessage(string message)
+        {
         }
     }
 }

--- a/OverlayPlugin.Core/OverlayForm.cs
+++ b/OverlayPlugin.Core/OverlayForm.cs
@@ -61,13 +61,13 @@ namespace RainbowMage.OverlayPlugin
 
         public bool Locked { get; set; }
 
-        public OverlayForm(string url, int maxFrameRate = 30)
+        public OverlayForm(string overlayName, string url, int maxFrameRate = 30)
         {
             InitializeComponent();
             Renderer.Initialize();
 
             this.maxFrameRate = maxFrameRate;
-            this.Renderer = new Renderer();
+            this.Renderer = new Renderer(overlayName);
             this.Renderer.Render += renderer_Render;
             this.MouseWheel += OverlayForm_MouseWheel;
 

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -84,6 +84,16 @@ namespace RainbowMage.OverlayPlugin
                         }
                     });
                 };
+                RainbowMage.HtmlRenderer.Renderer.OverlayMessage += (o, e) =>
+                {
+                    Task.Run(() =>
+                    {
+                        var targetOverlay = this.Overlays.FirstOrDefault(x => x.Name == e.Target);
+                        if (targetOverlay != null) {
+                            targetOverlay.OverlayMessage(e.Message);
+                        }
+                    });
+                };
                 RainbowMage.HtmlRenderer.Renderer.RendererFeatureRequest += (o, e) =>
                 {
                     Task.Run(() =>


### PR DESCRIPTION
This adds an overlayMessage() function to the OverlayPluginApi object,
which will call a virtual OverlayMessage() function on OverlayBase.
Plugins can override it and parse the string to do whatever they wish,
such as Text-to-Speech for example.

The sendMessage() function takes 2 arguments, which are the |name| of
the overlay plugin to send it to, and the |message| string to send.
overlayMessage() takes the same 2 arguments.

In order to send the overlayMessage() to the same plugin which is
running the javascript, the name of the plugin needs to be known,
but it is user defined. So we also add an |overlayName| readonly
string to the OverlayPluginApi object, that has the name of the
overlay plugin. Then the javascript may do the following to send
a string to its c# plugin:

OverlayPluginApi.overlayMessage(OverlayPluginApi.overlayName, 'hello');