### PR TITLE
Update English README to use correct release page

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -4,7 +4,7 @@ Plugin to show customizable mini parse and timeline overlay for Advanced Combat 
 
 ## Download
 
-You can download release and pre-release archives from [release page](https://github.com/RainbowMage/OverlayPlugin/releases).
+You can download release and pre-release archives from [release page](../../releases).
 
 ## System requirements
 


### PR DESCRIPTION
This should ensure folks get the releases page for whoever's GitHub account they're on by clicking the link.